### PR TITLE
Fix width of iframe inside message box.

### DIFF
--- a/src/styles/botui.scss
+++ b/src/styles/botui.scss
@@ -35,6 +35,10 @@
   &.human {
     float: right;
   }
+  
+  iframe {
+    width: 100%;
+  }
 }
 
 .botui-message-content-image {


### PR DESCRIPTION
The `iframe`, containing the example embedded gif, has a width greater than the width of the message box and thus breaks out of the message box. Here's an example: http://imgur.com/a/vRq7D